### PR TITLE
Static link instead of dynamic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache git make cmake gcc g++ libmad-dev \
     && ln -s googletest-release-1.8.0/googlemock googlemock \              
     && mkdir build \
     && cd build \
-    && cmake .. \
+    && cmake -D BUILD_STATIC=1 .. \
     && make \
     && cp audiowaveform* /bin \
     && cd \


### PR DESCRIPTION
This should allow for a more self-contained binary, whilst also allowing for easier compatibility across other distros